### PR TITLE
Add date to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,3 +16,4 @@ abstract: >-
   that allows encoding using any
   sentence_transformers model.
 license: Apache-2.0
+date-released: '2022-10-11'


### PR DESCRIPTION
Oops! Forgot the date in the CITATION.cff. Added one so it shows up in the bibtex (and therefore any latex document that uses it). Just used to the data of the latest release.